### PR TITLE
Fix conda-forge 0.9+ version for gdal

### DIFF
--- a/.ci_support/linux_.yaml
+++ b/.ci_support/linux_.yaml
@@ -4,11 +4,3 @@ channel_targets:
 - conda-forge main
 docker_image:
 - condaforge/linux-anvil-comp7
-numpy:
-- '1.17'
-pin_run_as_build:
-  python:
-    min_pin: x.x
-    max_pin: x.x
-python:
-- '3.7'

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,5 @@
 {% set version = "0.9.1" %}
+
 package:
   name: glymur
   version: {{ version }}
@@ -10,27 +11,21 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps -vv
   entry_points:
     - jp2dump=glymur.command_line:main
 
 requirements:
-  host:
+  build:
+    - python >=3.6
     - pip
-    - python >= 3.6
+  run:
+    - python >=3.6
     - setuptools
     - numpy
     - lxml
-    - mock
-    - contextlib2
-
-  run:
-    - python
-    - setuptools
-    - numpy >=1.7.0
-    - lxml >=2.3.2
-    - contextlib2 >=0.4
+    - gdal
     - openjpeg >=2.1.1
 
 test:


### PR DESCRIPTION
Use xarray as an example.  Fix python version dependency

MNT: Re-rendered with conda-build 3.18.11, conda-smithy 3.6.5, and conda-forge-pinning 2020.01.16

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
